### PR TITLE
refactor(mindmap): extract prepareLayoutTree from getData

### DIFF
--- a/docs/diagrams/mindmap-implementation-sequence.mmd
+++ b/docs/diagrams/mindmap-implementation-sequence.mmd
@@ -21,7 +21,6 @@ sequenceDiagram
     participant SVGDraw as svgDraw.ts
     participant Styles as styles.ts
     participant Output as Final SVG
-    participant Hello as yes
 
     Note over User, Output: Mindmap Implementation Flow
 
@@ -178,4 +177,4 @@ sequenceDiagram
     Note over DB, Styles: Configuration Options
     Note right of DB: Padding Calculations:<br/>Base padding from config<br/>RECT: ×2 padding<br/>ROUNDED_RECT: ×2 padding<br/>HEXAGON: ×2 padding
     Note right of Styles: Section Management:<br/>MAX_SECTIONS = 12<br/>Dynamic color generation<br/>Git theme integration
-    Note right of Renderer: Layout Parameters:<br/>Cytoscape configuration<br/>coseBilkent settings<br/>Node spacing rules
+    Note right of Renderer: Layout Parameters:<br/>Cytoscape configuration<br/>coseBilkent settings<br/>Node spacing rules 

--- a/docs/diagrams/mindmap-implementation-sequence.mmd
+++ b/docs/diagrams/mindmap-implementation-sequence.mmd
@@ -1,13 +1,13 @@
 ---
 references:
-  - "File: /packages/mermaid/src/diagrams/mindmap/mindmap-definition.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/mindmapDb.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/detector.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/mindmapTypes.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/mindmapRenderer.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/styles.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/svgDraw.ts"
-generationTime: 2025-01-28T16:00:00.000Z
+  - 'File: /packages/mermaid/src/diagrams/mindmap/mindmap-definition.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/mindmapDb.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/detector.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/mindmapTypes.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/mindmapRenderer.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/styles.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/svgDraw.ts'
+generationTime: '2026-08-28T22:12:46.308Z'
 ---
 sequenceDiagram
     participant User as User Input Text

--- a/docs/diagrams/mindmap-implementation-sequence.mmd
+++ b/docs/diagrams/mindmap-implementation-sequence.mmd
@@ -21,6 +21,7 @@ sequenceDiagram
     participant SVGDraw as svgDraw.ts
     participant Styles as styles.ts
     participant Output as Final SVG
+    participant Hello as yes
 
     Note over User, Output: Mindmap Implementation Flow
 
@@ -177,4 +178,4 @@ sequenceDiagram
     Note over DB, Styles: Configuration Options
     Note right of DB: Padding Calculations:<br/>Base padding from config<br/>RECT: ×2 padding<br/>ROUNDED_RECT: ×2 padding<br/>HEXAGON: ×2 padding
     Note right of Styles: Section Management:<br/>MAX_SECTIONS = 12<br/>Dynamic color generation<br/>Git theme integration
-    Note right of Renderer: Layout Parameters:<br/>Cytoscape configuration<br/>coseBilkent settings<br/>Node spacing rules 
+    Note right of Renderer: Layout Parameters:<br/>Cytoscape configuration<br/>coseBilkent settings<br/>Node spacing rules

--- a/packages/mermaid/src/diagrams/mindmap/mindmapDb.ts
+++ b/packages/mermaid/src/diagrams/mindmap/mindmapDb.ts
@@ -332,6 +332,29 @@ export class MindmapDB {
   }
 
   /**
+   * Prepare the mindmap tree for layout: assign section numbers, then convert the
+   * tree into the flat node and edge arrays the layout algorithms expect.
+   * @param root - The root node of the mindmap
+   * @returns The flattened nodes and the edges generated from the tree
+   */
+  public prepareLayoutTree(root: MindmapNode): {
+    nodes: MindmapLayoutNode[];
+    edges: MindmapLayoutEdge[];
+  } {
+    // Assign section numbers to all nodes based on their position relative to root
+    this.assignSections(root);
+
+    // Convert tree structure to flat arrays
+    const nodes: MindmapLayoutNode[] = [];
+    const edges: MindmapLayoutEdge[] = [];
+
+    this.flattenNodes(root, nodes);
+    this.generateEdges(root, edges);
+
+    return { nodes, edges };
+  }
+
+  /**
    * Get structured data for layout algorithms
    * Following the pattern established by ER diagrams
    * @returns Structured data containing nodes, edges, and config
@@ -357,15 +380,7 @@ export class MindmapDB {
     }
     log.debug('getData: mindmapRoot', mindmapRoot, config);
 
-    // Assign section numbers to all nodes based on their position relative to root
-    this.assignSections(mindmapRoot);
-
-    // Convert tree structure to flat arrays
-    const processedNodes: MindmapLayoutNode[] = [];
-    const processedEdges: MindmapLayoutEdge[] = [];
-
-    this.flattenNodes(mindmapRoot, processedNodes);
-    this.generateEdges(mindmapRoot, processedEdges);
+    const { nodes: processedNodes, edges: processedEdges } = this.prepareLayoutTree(mindmapRoot);
 
     log.debug(
       `getData: processed ${processedNodes.length} nodes and ${processedEdges.length} edges`

--- a/packages/mermaid/src/docs/diagrams/mindmap-implementation-sequence.mmd
+++ b/packages/mermaid/src/docs/diagrams/mindmap-implementation-sequence.mmd
@@ -1,13 +1,13 @@
 ---
 references:
-  - "File: /packages/mermaid/src/diagrams/mindmap/mindmap-definition.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/mindmapDb.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/detector.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/mindmapTypes.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/mindmapRenderer.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/styles.ts"
-  - "File: /packages/mermaid/src/diagrams/mindmap/svgDraw.ts"
-generationTime: 2025-01-28T16:00:00.000Z
+  - 'File: /packages/mermaid/src/diagrams/mindmap/mindmap-definition.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/mindmapDb.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/detector.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/mindmapTypes.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/mindmapRenderer.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/styles.ts'
+  - 'File: /packages/mermaid/src/diagrams/mindmap/svgDraw.ts'
+generationTime: '2026-08-28T22:12:46.106Z'
 ---
 sequenceDiagram
     participant User as User Input Text


### PR DESCRIPTION
Moves the section-assignment and tree-flattening steps out of `MindmapDB.getData()` into a named `prepareLayoutTree()` method, so building the layout data is a single explicit step.

Behavior is unchanged — this is a pure extraction.

## Why this PR exists

Testing the **Mermaid Diagram Sync** GitHub app. `packages/mermaid/src/diagrams/mindmap/mindmapDb.ts` is listed in the `references:` frontmatter of `packages/mermaid/src/docs/diagrams/mindmap-implementation-sequence.mmd`, so this PR should cause that diagram to be regenerated and committed back to this branch by the bot.

## Verification

- `vitest run packages/mermaid/src/diagrams/mindmap` — 36/36 passed
- `tsc --noEmit -p packages/mermaid/tsconfig.json` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)