### PR TITLE
fix(pie): log ignored duplicate sections

### DIFF
--- a/packages/mermaid/src/diagrams/pie/pieDb.ts
+++ b/packages/mermaid/src/diagrams/pie/pieDb.ts
@@ -39,10 +39,14 @@ const addSection = ({ label, value }: D3Section): void => {
       `"${label}" has invalid value: ${value}. Negative values are not allowed in pie charts. All slice values must be >= 0.`
     );
   }
-  if (!sections.has(label)) {
-    sections.set(label, value);
-    log.debug(`added new section: ${label}, with value: ${value}`);
+  if (sections.has(label)) {
+    log.debug(
+      `ignoring duplicate section: ${label}, keeping existing value: ${sections.get(label)}`
+    );
+    return;
   }
+  sections.set(label, value);
+  log.debug(`added new section: ${label}, with value: ${value}`);
 };
 
 const getSections = (): Sections => sections;


### PR DESCRIPTION
`addSection()` silently dropped a repeated label, which made duplicate data in a pie definition hard to spot. This logs the ignored duplicate along with the value being kept, and flattens the branch with an early return.

Behavior is otherwise unchanged — duplicates are still ignored, first value wins.

## Why this PR exists

Control case for the **Mermaid Diagram Sync** app, paired with #9.

`packages/mermaid/src/diagrams/pie/pieDb.ts` appears in **no** diagram's `references:` frontmatter, so the expectation is that the bot does **nothing** here — no diagram is connected to this file. If a diagram does get generated, the app creates diagrams for undocumented code, not just syncs existing ones.

## Verification

- `vitest run packages/mermaid/src/diagrams/pie` — 14 passed, 2 todo

🤖 Generated with [Claude Code](https://claude.com/claude-code)